### PR TITLE
new conda use 'conda' over 'source'

### DIFF
--- a/src/CJ/Python.pm
+++ b/src/CJ/Python.pm
@@ -214,7 +214,7 @@ HERE
 conda list -e > ${DIR}/${PID}_py_conda_req.txt
     
 # Get out of virtual env and remove it
-source deactivate
+conda deactivate
     
 BASH
     
@@ -317,7 +317,7 @@ fi
 
     
 # Get out of virtual env and remove it
-source deactivate
+conda deactivate
     
     
 BASH


### PR DESCRIPTION
newer versions of conda now use 'conda deactivate' rather than 'source deactivate'. There is now a deprecation warning that says the following:

DeprecationWarning: 'source deactivate' is deprecated. Use 'conda deactivate'.